### PR TITLE
Set a valid user-agent for the requests.

### DIFF
--- a/src/net/download.cpp
+++ b/src/net/download.cpp
@@ -94,6 +94,7 @@ std::string curlDownloadKeepName(char const*const url, std::string dst) {
     curl = curl_easy_init();
     if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
 		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);


### PR DESCRIPTION
This way the homebrew won't get blocked by the recently added CloudFlare firewall rules.